### PR TITLE
Tweaked sheet dark mode and added test sheet

### DIFF
--- a/js/indexDarkModeScript.js
+++ b/js/indexDarkModeScript.js
@@ -1,6 +1,6 @@
 window.addEventListener("load", function() {
 let sideBar = document.getElementById("sidebar")
-let toggleDarkModeBtn = "<div id='darkModeBtn' style='background-color:#121212; font-size:1.5em; height:2em;color:white;" +
+let toggleDarkModeBtn = "<div id='darkModeBtn' style='background-color:#121212; font-size:1.5em; height:2em;color:white; cursor:pointer;" +
     "border-radius:4px; display: flex; align-items: center; justify-content: center; margin-bottom:5px;'>Turn on dark mode 🌙</div>"
 sideBar.innerHTML = toggleDarkModeBtn + sideBar.innerHTML
 document.getElementById("darkModeBtn").addEventListener("click", function () {
@@ -10,7 +10,7 @@ document.getElementById("darkModeBtn").addEventListener("click", function () {
     if (contentWrapper.style.backgroundColor != "rgb(18, 18, 18)") {
         sidebar.style = "background: #121212; color: lightgray;"
         contentWrapper.style = "background: #121212; color: lightgray;"
-        darkModeBtn.innerHTML = "Turn on white mode ☀️"
+        darkModeBtn.innerHTML = "Turn on light mode ☀️"
         darkModeBtn.style.background = "#f2f2f2"
         darkModeBtn.style.color = "#121212"
         localStorage.setItem("darkMode", true)

--- a/js/sheetDarkModeScript.js
+++ b/js/sheetDarkModeScript.js
@@ -1,20 +1,23 @@
   window.addEventListener("load", function() {
     let body = document.getElementsByTagName("body")[0]
     let toggleDarkModeBtn = "<div id='darkModeBtn' style='background-color:#121212; font-size:1.3em; height:1.5em;color:white; position:absolute; right: 8px; top:8px;" +
-        "border-radius:4px; display: flex; align-items: center; justify-content: center; margin-bottom:5px; padding:5px'>Turn on dark mode 🌙</div>"
+        "border-radius:4px; display: flex; align-items: center; justify-content: center; cursor:pointer; margin-bottom:5px; padding:5px'>Turn on dark mode 🌙</div>"
     body.innerHTML += toggleDarkModeBtn
     let darkModeBtn = document.getElementById("darkModeBtn")
     document.getElementById("darkModeBtn").addEventListener("click", function () {
         if (body.style.backgroundColor != "rgb(18, 18, 18)") {
             body.style = "background: #121212; color: lightgray;"
-            darkModeBtn.innerHTML = "Turn on white mode ☀️"
+            darkModeBtn.innerHTML = "Turn on light mode ☀️"
             darkModeBtn.style.background = "#f2f2f2"
             darkModeBtn.style.color = "#121212"
             let tables = document.getElementsByTagName("table")
             for (let i = 1; i < tables.length; i++) {
-                if (tables[i].className != "voice") {
-                    tables[i].firstChild.style.backgroundColor = "#323232"
-                    tables[i].style = "border: solid 1.5px #666;"
+                console.log(tables[i].classList)
+                if (!tables[i].classList.value.includes("silent") && !tables[i].classList.value.includes("voice") && !tables[i].classList.value.includes("repeat")) {
+                        tables[i].firstChild.style.backgroundColor = "#323232"
+                        tables[i].style = "border: solid 1.5px #666;"
+                }else{
+                    tables[i].style.border = "solid 1.5px transparent"
                 }
             }
             tables[0].style = "border: solid 1.5px #666;"

--- a/songs/darkModeTest.html
+++ b/songs/darkModeTest.html
@@ -1,0 +1,7650 @@
+<!DOCTYPE html>
+<html xmlns:svg="http://www.w3.org/2000/svg">
+<head>
+<title>American folk songs</title>
+<script src="../js/sheetDarkModeScript.js"> </script>
+<style type="text/css">
+html {
+  scroll-behavior: smooth;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+ 
+/* <!-- Defines the em unit--> */
+body {
+  font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans CJK KR", "Noto Sans CJK SC", "Noto Sans CJK TC", "Avenir", Arial, sans-serif;
+  font-size: 12pt;
+}
+
+/* <!-- Song title --> */
+h1, svg text.title {
+    font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans CJK KR", "Noto Sans CJK SC", "Noto Sans CJK TC", "Avenir", Arial, sans-serif;
+	font-size: 1.3em;
+	font: bold;
+}
+
+/* <!-- Song headers (HTML only) --> */
+p, svg text.headers {
+    font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans CJK KR", "Noto Sans CJK SC", "Noto Sans CJK TC", "Avenir", Arial, sans-serif;
+	font-size: 0.8em;
+	line-height: 50%;
+}
+
+.note-root, .note-diamond, .note-circle {
+  transform: scale(1.0);
+  -ms-transform: scale(1.0);
+  -webkit-transform: scale(1.0);
+}
+
+/* <!-- Alignment of SVG (HTML only) --> */
+/* <!-- Seems to have no effect ? --> */
+.note-root svg, .note-diamond svg, .note-circle svg {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/* <!-- Sky chord chart: a table with rounded edges (HTML only) --> */
+table {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 4px;
+  margin-right: 0px;
+  padding: 0px;
+  display: inline-block;
+  border-style: solid;
+  border-radius: 5px;
+  border-width: 1px;
+  border-color: black;
+  border-spacing: 0 auto;
+}
+
+/* <!-- Sky chord chart: a table with rounded edges (SVG only) --> */
+svg rect.harp {
+  fill:white;
+  stroke-width:1;
+  stroke:black;
+}
+
+
+/* <!-- WARNING: The td font size affects the note size! (HTML only)--> */
+td {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  margin: 0px;
+  font-size: 1.0em;
+}
+
+/* <!-- Makes the table disappear in case of broken chord  (HTML only)--> */
+table.broken {
+  border-color: white;
+  border-width: 0;
+}
+
+/* <!-- Makes the table disappear in case of broken chord  (SVG only)--> */
+svg.broken rect{
+  fill:none;
+  stroke-width:0;
+  stroke:white;
+}
+
+/* <!-- Silent table  (HTML only)--> */
+table.silent {
+  border-color:#BBBBBB;
+  border-width:0;
+}
+
+/* <!-- Silent table  (HTML only)--> */
+svg.silent rect {
+  stroke: grey;
+  stroke-width:0;
+  fill:none;
+}
+
+table.voice {
+  margin-top: 0px;
+  margin-bottom: 0px;
+  margin-left: 4px;
+  margin-right: 0px;
+  padding: 0px;
+  border-radius: 0px;
+  border-width: 0px;
+}
+
+table.voice td {
+  padding-top: 0px;
+  padding-bottom: 0px;
+  margin: 0px;
+  font-size: 0.8em;
+  width: 7.5em;
+  text-align: center;
+}
+
+/* <!-- Sky voice (SVG only) --> */
+svg text.voice {
+  font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans CJK KR", "Noto Sans CJK SC", "Noto Sans CJK TC", "Avenir", Arial, sans-serif;
+  font-size: 0.8em;
+  stroke: none;
+  fill:black;
+  dominant-baseline: middle;
+}
+
+/* <!-- Invisible table to contain the repetition mark --> */
+table.repeat {
+  margin: 0px;
+  padding: 0px;
+  border-radius: 0px;
+  border-width: 0px;
+  font-size: 0.9em;
+}
+
+/* <!-- Bottom-left corner repetition mark --> */
+svg.repeat text.repeat {
+  stroke: none;
+  fill:black;
+  dominant-baseline: baseline;
+  font-size: 0.9em;
+  font-family: "Noto Sans", "Noto Sans CJK JP", "Noto Sans CJK KR", "Noto Sans CJK SC", "Noto Sans CJK TC", "Avenir", Arial, sans-serif;
+}
+
+
+/* <!-- Horizontal line --> */
+hr {
+  height: 2px;
+  background-color: #BBBBBB;
+  border: none;
+  opacity: 1;
+  padding: 0;
+  margin-top: 0px;
+  margin-bottom: 4px;   
+}
+
+svg line.divide {
+	stroke: grey;
+	stroke-width: 1.0px;
+}
+
+
+/* <!-- TODO: Check if this has no effect ??? --> */
+/* 
+path.instrument-button{
+	fill:#FF0000;
+	opacity:0.4;
+}
+ */
+ 
+/* <!-- TODO: Check if this has no effect ??? --> */
+#transcript {
+  margin: 0 0;
+}
+
+
+/* <!-- Small buttons showing notes positions --> */
+svg.harp-button-0 .unhighlighted.instrument-button-icon,
+svg.harp-button-1 .unhighlighted.instrument-button-icon,
+svg.harp-button-2 .unhighlighted.instrument-button-icon,
+svg.harp-button-3 .unhighlighted.instrument-button-icon,
+svg.harp-button-4 .unhighlighted.instrument-button-icon {
+  stroke-width: 0;
+  stroke: white;
+  fill: rgb(194,240,194);
+  opacity: 1;
+}
+
+/* <!-- Small buttons showing notes positions --> */
+svg.harp-button-5 .unhighlighted.instrument-button-icon,
+svg.harp-button-6 .unhighlighted.instrument-button-icon,
+svg.harp-button-7 .unhighlighted.instrument-button-icon,
+svg.harp-button-8 .unhighlighted.instrument-button-icon,
+svg.harp-button-9 .unhighlighted.instrument-button-icon {
+  stroke-width: 0;
+  stroke: white;
+  fill: rgb(179,236,255);
+  opacity: 1;
+}
+
+/* <!-- Small buttons showing notes positions --> */
+svg.harp-button-10 .unhighlighted.instrument-button-icon,
+svg.harp-button-11 .unhighlighted.instrument-button-icon,
+svg.harp-button-12 .unhighlighted.instrument-button-icon,
+svg.harp-button-13 .unhighlighted.instrument-button-icon,
+svg.harp-button-14 .unhighlighted.instrument-button-icon {
+  stroke-width: 0;
+  stroke: white;
+  fill: rgb(255,185,223);
+  opacity: 1;
+}
+
+/* <!-- Note background when the chord is or is silent --> */
+table.broken .highlighted-0.instrument-button,
+table.silent .highlighted-0.instrument-button {
+  stroke-width: 0;
+  stroke: white;
+  fill: none;
+}
+
+/* <!-- Small note buttons when the chord is broken --> */
+table.broken .unhighlighted.instrument-button-icon,
+svg.broken .unhighlighted.instrument-button-icon {
+  stroke-width: 0;
+  stroke: white;
+  fill: none;
+}
+
+/* <!-- Small note buttons when the chord is silent --> */
+table.silent .unhighlighted.instrument-button-icon,
+svg.silent .unhighlighted.instrument-button-icon {
+  stroke-width: 0;
+  stroke: white;
+  fill: none;
+}
+
+/* <!-- Middle note button when the chord is silent --> */
+table.silent svg.harp-button-7 .unhighlighted.instrument-button-icon,
+svg.silent svg.harp-button-7 .unhighlighted.instrument-button-icon,
+svg.silent.harp-button-7 .unhighlighted.instrument-button-icon {
+  stroke-width: 0;
+  stroke: white;
+  fill: #BBBBBB;
+  opacity: 1;
+}
+
+/* <!-- Red question mark when table is broken --> */
+table.broken text,
+svg.broken text {
+  fill: red;
+  text-anchor:middle;
+  font-size:600%;
+  stroke-width:0.05em;
+  stroke:red;
+}
+
+
+/* <!-- Note decoration (circle, diamond) --> */
+.highlighted-0.instrument-button-icon {
+  stroke-width: 5;
+  stroke: white;
+  fill: none;
+}
+
+/* <!-- Note background color in first row --> */
+svg.harp-button-0 path.highlighted-0,
+svg.harp-button-1 path.highlighted-0,
+svg.harp-button-2 path.highlighted-0,
+svg.harp-button-3 path.highlighted-0,
+svg.harp-button-4 path.highlighted-0 {
+  fill: limegreen;
+  opacity: 1.0;
+}
+
+/* <!-- Note background color in second row --> */
+svg.harp-button-5 path.highlighted-0,
+svg.harp-button-6 path.highlighted-0,
+svg.harp-button-7 path.highlighted-0,
+svg.harp-button-8 path.highlighted-0,
+svg.harp-button-9 path.highlighted-0 {
+  fill: deepskyblue;
+  opacity: 1.0;
+}
+
+/* <!-- Note background color in third row --> */
+svg.harp-button-10 path.highlighted-0,
+svg.harp-button-11 path.highlighted-0,
+svg.harp-button-12 path.highlighted-0,
+svg.harp-button-13 path.highlighted-0,
+svg.harp-button-14 path.highlighted-0 {
+  fill: deeppink;
+  opacity: 1.0;
+}
+
+/* <!-- Element background color for icons in ../elements
+Set to none to have a transparent SVG, and a transparent PNG with alpha layer (RGBA) later
+Set to white to make the background white in RGB mode, and the PNG background white when converted to RGB
+--> */
+svg rect.harp-background {
+	fill:white;	
+}
+
+svg rect.note-background {
+	fill:white;	
+}
+
+/* <!-- Below the styles for buttons in a quaver --> */
+.highlighted-7 {
+  fill: rgb(68,1,84);
+  opacity: 1.0;
+}
+
+.highlighted-7.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+.highlighted-6 {
+  fill: rgb(68,57,130);
+  opacity: 1.0;
+}
+
+.highlighted-6.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+.highlighted-5 {
+  fill: rgb(48,103,141);
+  opacity: 1.0;
+}
+
+.highlighted-5.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+
+.highlighted-4 {
+  fill: rgb(32,144,140);
+  opacity: 1.0;
+}
+
+.highlighted-4.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+.highlighted-3 {
+  fill: rgb(53,183,120);
+  opacity: 1.0;
+}
+
+.highlighted-3.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+.highlighted-2 {
+  fill: rgb(144,214,67);
+  opacity: 1.0;
+}
+
+.highlighted-2.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+.highlighted-1 {
+  fill: rgb(253,231,36);
+  opacity: 1.0;
+}
+
+.highlighted-1.instrument-button-icon {
+  stroke-width: 3;
+  stroke: white;
+  fill: none;
+}
+
+/* <!-- Button styles if chord has en broken --> */
+/* <!-- TODO: Check if this has no effect ??? --> */
+/* 
+.instrument-button-icon.silent {
+  fill: red;
+  stroke: red;
+}
+
+.note-diamond.silent {
+  fill: red;
+  stroke: red;
+}
+ */
+
+
+
+</style>
+<meta charset="utf-8"/></head>
+<body>
+	<table id="navigation">
+    <tr>
+      <td>
+        <a href="../index.html"><img src="../assets/images/sky-music-logo-sheets.png" width="100" height="100" /></a>
+      </td>
+      <td>
+        <h1><a href="../index.html">Sky Music</a></h1>
+      </td>
+    </tr>
+  </table>
+<h1> American folk songs </h1>
+<p> <b>Original Artist(s):</b> Various </p>
+<p> <b>Transcript:</b> mimizan </p>
+<p> <b>Musical key:</b> C </p>
+<div id="transcript">
+
+<br />
+<table class="voice"><tr><td>==You are</td></tr></table> <table class="voice"><tr><td>my sunshine</td></tr></table> 
+<hr />
+<table class="harp harp-2 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-2 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-3 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-4 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-4 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-5 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-6 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-7 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-7 repeat"><tr><td>x2</td></tr></table> 
+<br />
+<table class="voice"><tr><td>You are</td></tr></table> <table class="voice"><tr><td>my</td></tr></table> <table class="voice"><tr><td>sunshine</td></tr></table> <table class="voice"><tr><td>My</td></tr></table> <table class="voice"><tr><td>on-</td></tr></table> <table class="voice"><tr><td>-ly</td></tr></table> <table class="voice"><tr><td>sunshine</td></tr></table> 
+<hr />
+<table class="harp harp-15 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-1"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-1"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-4" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-4"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-16 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-16 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-17 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-18 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-1"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-1"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-4" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-4"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-19 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-19 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-20 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-21 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-22 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-1"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-1"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-4" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-4"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-23 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-23 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-24 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-25 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==When the</td></tr></table> <table class="voice"><tr><td>saints go</td></tr></table> <table class="voice"><tr><td>marching in</td></tr></table> 
+<hr />
+<table class="harp harp-30 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-31 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-32 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-33 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-34 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-35 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-36 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>Oh</td></tr></table> <table class="voice"><tr><td>when</td></tr></table> <table class="voice"><tr><td>the</td></tr></table> <table class="voice"><tr><td>saints,</td></tr></table> <table class="voice"><tr><td>go</td></tr></table> <table class="voice"><tr><td>marching in</td></tr></table> 
+<hr />
+<table class="harp harp-43 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-44 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-45 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-46 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-47 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-48 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-49 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-50 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-51 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-52 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-52 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-53 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-54 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-55 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-56 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-57 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-58 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-58 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-59 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-60 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-61 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-62 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-63 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-64 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-65 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==London bridge</td></tr></table> <table class="voice"><tr><td>is falling</td></tr></table> <table class="voice"><tr><td>down</td></tr></table> 
+<hr />
+<table class="harp harp-70 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-71 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-72 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-73 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-74 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-75 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-76 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-77 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-1"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-78 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-79 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>Lon-</td></tr></table> <table class="voice"><tr><td>_</td></tr></table> <table class="voice"><tr><td>-don</td></tr></table> <table class="voice"><tr><td>bridge is fal</td></tr></table> <table class="voice"><tr><td>-ling</td></tr></table> <table class="voice"><tr><td>down</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>falling down</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>falling down,</td></tr></table> 
+<hr />
+<table class="harp harp-90 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-91 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-92 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-93 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-94 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-95 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-96 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-97 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-98 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-99 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-100 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>Lon-</td></tr></table> <table class="voice"><tr><td>_</td></tr></table> <table class="voice"><tr><td>-don</td></tr></table> <table class="voice"><tr><td>bridge is fal</td></tr></table> <table class="voice"><tr><td>-ling</td></tr></table> <table class="voice"><tr><td>down</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>my</td></tr></table> <table class="voice"><tr><td>fair</td></tr></table> <table class="voice"><tr><td>la-</td></tr></table> <table class="voice"><tr><td>-dy</td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==Michael</td></tr></table> <table class="voice"><tr><td>(row your boat</td></tr></table> <table class="voice"><tr><td>ashore)</td></tr></table> 
+<hr />
+<table class="harp harp-116 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-117 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-118 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-119 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-120 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-121 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-122 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-123 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-124 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-125 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-126 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-127 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-128 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-129 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-130 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-131 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-132 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-133 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-134 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-135 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-136 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-137 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-138 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-139 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-140 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==Oh Susanna</td></tr></table> 
+<hr />
+<table class="harp harp-143 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-144 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-145 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-146 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-147 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-147 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-148 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-149 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-150 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-151 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-152 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-153 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-154 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-154 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-155 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-156 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-157 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>I</td></tr></table> <table class="voice"><tr><td>-</td></tr></table> <table class="voice"><tr><td>came</td></tr></table> <table class="voice"><tr><td>to</td></tr></table> <table class="voice"><tr><td>Ala-</td></tr></table> <table class="voice"><tr><td>-ba-</td></tr></table> <table class="voice"><tr><td>-ma</td></tr></table> <table class="voice"><tr><td>with</td></tr></table> <table class="voice"><tr><td>my</td></tr></table> <table class="voice"><tr><td>banjo</td></tr></table> <table class="voice"><tr><td>on</td></tr></table> <table class="voice"><tr><td>my</td></tr></table> <table class="voice"><tr><td>knees</td></tr></table> 
+<hr />
+<table class="harp harp-171 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-172 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-173 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-174 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-175 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-176 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-177 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-178 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-179 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-180 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-181 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-182 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-182 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-183 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-183 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-184 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-185 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-185 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-186 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-187 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-187 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-188 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-189 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-190 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-190 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-191 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-192 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-193 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-194 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-195 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-196 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-197 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-198 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-198 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-199 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-200 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-201 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-202 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-203 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-204 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-205 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-205 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-206 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-206 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-207 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==Three blind</td></tr></table> <table class="voice"><tr><td>mice</td></tr></table> 
+<hr />
+<table class="harp harp-211 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-212 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-213 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-214 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-215 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-216 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-217 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>Three</td></tr></table> <table class="voice"><tr><td>blind</td></tr></table> <table class="voice"><tr><td>mice</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>three</td></tr></table> <table class="voice"><tr><td>blind</td></tr></table> <table class="voice"><tr><td>mice</td></tr></table> 
+<hr />
+<table class="harp harp-225 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-226 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-226 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-227 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-228 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-229 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-230 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-230 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-231 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-232 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-233 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-233 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-234 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-235 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-236 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-237 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-238 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-238 repeat"><tr><td>x2</td></tr></table> 
+<hr />
+<table class="harp harp-239 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-240 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-241 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-241 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-242 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-243 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-244 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-245 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-246 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-247 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-247 repeat"><tr><td>x2</td></tr></table> 
+<hr />
+<table class="harp harp-248 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-249 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-250 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-250 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-251 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-252 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-253 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-254 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-255 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-255 repeat"><tr><td>x3</td></tr></table> 
+<hr />
+<table class="harp harp-256 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-257 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-258 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-259 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-260 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==Kum ba Ya</td></tr></table> 
+<hr />
+<table class="harp harp-263 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-264 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-265 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-265 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-266 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-266 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-267 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-268 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-269 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-270 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-270 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-271 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-272 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-273 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-274 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-275 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-276 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-276 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-277 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-277 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-278 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<hr />
+<table class="harp harp-279 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-280 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-281 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-282 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-282 repeat"><tr><td>x2</td></tr></table> <table class="harp harp-283 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>_</td></tr></table> 
+<br />
+<table class="voice"><tr><td>==Row row row</td></tr></table> <table class="voice"><tr><td>your boat</td></tr></table> 
+<hr />
+<table class="harp harp-287 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-288 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-289 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-290 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-291 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-292 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-293 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-294 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-295 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-296 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-297 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-298 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-299 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+<br />
+<table class="voice"><tr><td>Row</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>row</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>row</td></tr></table> <table class="voice"><tr><td>your</td></tr></table> <table class="voice"><tr><td>boat</td></tr></table> <table class="voice"><tr><td>,</td></tr></table> <table class="voice"><tr><td>gent-</td></tr></table> <table class="voice"><tr><td>-ly</td></tr></table> <table class="voice"><tr><td>down</td></tr></table> <table class="voice"><tr><td>the</td></tr></table> <table class="voice"><tr><td>stream</td></tr></table> 
+<hr />
+<table class="harp harp-313 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-313 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-314 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-314 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-315 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-0"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-315 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-316 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-0" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-0"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-0"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table><table class="harp-316 repeat"><tr><td>x3</td></tr></table> <table class="harp harp-317 silent"><tr><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="26" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle unhighlighted harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond unhighlighted harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root unhighlighted harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> <table class="harp harp-318 "><tr><td>
+<svg x="0" y="0" class="note-root harp-button-0" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-5" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.5" cy="45.4" r="26" class="instrument-button-icon highlighted-5"/><rect x="19.5" y="19.3" transform="matrix(-0.7071 0.7071 -0.7071 -0.7071 109.7415 45.2438)" width="52" height="52" class="instrument-button-icon highlighted-5"/>
+</svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-1" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-4" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-4"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-2" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-3" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-3"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-3" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-2" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<rect x="22.6" y="22.7" transform="matrix(-0.7071 -0.7071 0.7071 -0.7071 45.3002 109.5842)" width="45.4" height="45.4" class="instrument-button-icon highlighted-2"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-4" width="1em" height="1em" viewBox="0 0 91 91">
+<path class="instrument-button highlighted-1" d="M90.7 76.5c0 7.8-6.3 14.2-14.2 14.2H14.2C6.3 90.7 0 84.4 0 76.5V14.2C0 6.3 6.3 0 14.2 0h62.3c7.8 0 14.2 6.3 14.2 14.2V76.5z"/>
+<circle cx="45.4" cy="45.4" r="25.5" class="instrument-button-icon highlighted-1"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-5" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-6" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-7" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-8" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-9" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr><tr><td>
+<svg x="0" y="0" class="note-circle harp-button-10" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-11" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-circle harp-button-12" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-diamond harp-button-13" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td><td>
+<svg x="0" y="0" class="note-root harp-button-14" width="1em" height="1em" viewBox="0 0 91 91">
+<circle cx="45.4" cy="45.4" r="12" class="instrument-button-icon unhighlighted"/></svg></td></tr></table> 
+</div>
+</body>
+</html>


### PR DESCRIPTION
What should be changed in the sheet generator: 

1) Include the dark mode script in the head

2) change the "table.silent" style to this:
`table.silent{
border-color:transparent;
}`

this makes all the tables the exact same width, currently the tables that are silent take some pixels less space making the whole row slightly shifted